### PR TITLE
feat: 유저 스틸컷 삭제 API

### DIFF
--- a/src/main/java/com/modura/modura_server/domain/user/controller/UserController.java
+++ b/src/main/java/com/modura/modura_server/domain/user/controller/UserController.java
@@ -29,7 +29,7 @@ public class UserController {
     @Operation(summary = "유저 정보 등록")
     @PatchMapping
     public ApiResponse<Void> updateUser(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                              @Valid @RequestBody UserRequestDTO.UpdateUserDTO request) {
+                                        @Valid @RequestBody UserRequestDTO.UpdateUserDTO request) {
 
         Long userId = userDetails.getUser().getId();
         userCommandService.updateUser(userId, request);
@@ -40,7 +40,7 @@ public class UserController {
     @Operation(summary = "찜한 컨텐츠 조회")
     @GetMapping("/likes/contents")
     public ApiResponse<SearchResponseDTO.SearchContentListDTO> getLikedContent(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                                              @RequestParam(name = "type") @NotBlank String type) {
+                                                                               @RequestParam(name = "type") @NotBlank String type) {
 
         Long userId = userDetails.getUser().getId();
         SearchResponseDTO.SearchContentListDTO response = userQueryService.getLikedContent(userId, type);
@@ -82,11 +82,22 @@ public class UserController {
     @Operation(summary = "작성한 리뷰 조회")
     @GetMapping("/reviews")
     public ApiResponse<UserResponseDTO.GetReviewListDTO> getReview(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                                               @RequestParam(name = "type") @NotBlank String type) {
+                                                                   @RequestParam(name = "type") @NotBlank String type) {
 
         Long userId = userDetails.getUser().getId();
         UserResponseDTO.GetReviewListDTO response = userQueryService.getReview(userId, type);
 
         return ApiResponse.onSuccess(response);
+    }
+
+    @Operation(summary = "유저 스틸컷 삭제")
+    @DeleteMapping("/stillcuts/{stillcutId}")
+    public ApiResponse<Void> delMyStillcut(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                             @PathVariable Long stillcutId) {
+
+        Long userId = userDetails.getUser().getId();
+        userCommandService.delMyStillcut(userId, stillcutId);
+
+        return ApiResponse.onSuccess(null);
     }
 }

--- a/src/main/java/com/modura/modura_server/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/modura/modura_server/domain/user/service/UserCommandService.java
@@ -3,5 +3,7 @@ package com.modura.modura_server.domain.user.service;
 import com.modura.modura_server.domain.user.dto.UserRequestDTO;
 
 public interface UserCommandService {
+
     void updateUser(Long userId, UserRequestDTO.UpdateUserDTO request);
+    void delMyStillcut(Long userId, Long stillcutId);
 }

--- a/src/main/java/com/modura/modura_server/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/com/modura/modura_server/domain/user/service/UserCommandServiceImpl.java
@@ -5,10 +5,13 @@ import com.modura.modura_server.domain.content.repository.CategoryRepository;
 import com.modura.modura_server.domain.user.dto.UserRequestDTO;
 import com.modura.modura_server.domain.user.entity.User;
 import com.modura.modura_server.domain.user.entity.UserCategory;
+import com.modura.modura_server.domain.user.entity.UserStillcut;
 import com.modura.modura_server.domain.user.repository.UserCategoryRepository;
 import com.modura.modura_server.domain.user.repository.UserRepository;
+import com.modura.modura_server.domain.user.repository.UserStillcutRepository;
 import com.modura.modura_server.global.exception.BusinessException;
 import com.modura.modura_server.global.response.code.status.ErrorStatus;
+import com.modura.modura_server.global.s3.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +26,8 @@ public class UserCommandServiceImpl implements UserCommandService {
     private final UserRepository userRepository;
     private final UserCategoryRepository userCategoryRepository;
     private final CategoryRepository categoryRepository;
+    private final UserStillcutRepository userStillcutRepository;
+    private final S3Service s3Service;
 
     @Override
     @Transactional
@@ -55,5 +60,19 @@ public class UserCommandServiceImpl implements UserCommandService {
 
             userCategoryRepository.saveAll(newUserCategories);
         }
+    }
+
+    @Override
+    @Transactional
+    public void delMyStillcut(Long userId, Long stillcutId) {
+
+        UserStillcut userStillcut = userStillcutRepository.findUserDetailsById(userId, stillcutId)
+                .orElseThrow(() -> new BusinessException(ErrorStatus.USER_STILLCUT_NOT_FOUND));
+
+        // S3에서 원본 이미지 파일 삭제
+        String imageKey = userStillcut.getImageUrl();
+        s3Service.deleteFile(imageKey);
+
+        userStillcutRepository.delete(userStillcut);
     }
 }


### PR DESCRIPTION
## 🎋 작업중인 브랜치 및 이슈

- #84 


## 🔑 주요 변경사항

- DELETE /users/stillcuts/{stillcutId} 구현


## Check List
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자가 자신의 스틸컷을 삭제할 수 있는 기능이 추가되었습니다. 인증된 사용자는 스틸컷 ID를 지정하여 삭제 요청을 보낼 수 있으며, 시스템에서 저장된 이미지 및 관련 데이터가 함께 제거됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->